### PR TITLE
fixes #4: removing extension check in favor of exclude and include options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import { extname } from 'path';
 import acorn from 'acorn';
 import { walk } from 'estree-walker';
 import MagicString from 'magic-string';
@@ -34,7 +33,9 @@ function flatten ( node ) {
 }
 
 export default function strip ( options = {} ) {
-	const filter = createFilter( options.include, options.exclude );
+	const include = options.include || '**/*.js';
+	const exclude = options.exclude;
+	const filter = createFilter( include, exclude );
 	const sourceMap = options.sourceMap !== false;
 
 	const removeDebuggerStatements = options.debugger !== false;
@@ -49,7 +50,6 @@ export default function strip ( options = {} ) {
 
 		transform ( code, id ) {
 			if ( !filter( id ) ) return null;
-			if ( extname( id ) !== '.js' ) return null;
 			if ( !firstpass.test( code ) ) return null;
 
 			let ast;

--- a/test/test.js
+++ b/test/test.js
@@ -1,10 +1,12 @@
 const fs = require( 'fs' );
 const assert = require( 'assert' );
 const strip = require( '..' );
+const path = require('path');
 
 function compare ( sample, options ) {
-	const input = fs.readFileSync( `test/samples/${sample}/input.js`, 'utf-8' );
-	const output = strip( options ).transform( input, 'input.js' );
+	const filename = path.resolve(`test/samples/${sample}/input.js`);
+	const input = fs.readFileSync( filename, 'utf-8' );
+	const output = strip( options ).transform( input, filename );
 
 	assert.equal( output ? output.code : input, fs.readFileSync( `test/samples/${sample}/output.js`, 'utf-8' ) );
 }


### PR DESCRIPTION
```js
// rollup.config.js
export default {
  entry: 'src/index.js',
  dest: 'dist/my-lib.js',
  plugins: [
    typescript({...}),
    strip({
      include: ['**/*.js', '**/*.ts']
    })
  ]
};
```

I preserved the existing behavior by falling back to a default value of `**/*.js` for include, but users can now overrule that and strip code from any extension if they have the right order in the rollup configuration.