### PR TITLE
Add acorn option overrides and default ecmaVersion 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,16 +25,16 @@
   },
   "homepage": "https://github.com/rollup/rollup-plugin-strip#readme",
   "dependencies": {
-    "acorn": "^3.1.0",
-    "estree-walker": "^0.2.1",
-    "magic-string": "^0.15.0",
-    "rollup-pluginutils": "^1.3.1"
+    "acorn": "^5.4.1",
+    "estree-walker": "^0.5.1",
+    "magic-string": "^0.22.4",
+    "rollup-pluginutils": "^2.0.1"
   },
   "devDependencies": {
-    "eslint": "^2.11.1",
-    "mocha": "^2.5.3",
-    "rollup": "^0.30.0",
-    "rollup-plugin-buble": "^0.10.0"
+    "eslint": "^4.17.0",
+    "mocha": "^5.0.0",
+    "rollup": "^0.55.3",
+    "rollup-plugin-buble": "^0.18.0"
   },
   "files": [
     "dist"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,14 +3,14 @@ import buble from 'rollup-plugin-buble';
 export default {
 	input: 'src/index.js',
 	plugins: [ buble() ],
-	targets: [
+	output: [
 		{
 			format: 'cjs',
-			dest: 'dist/rollup-plugin-strip.cjs.js'
+			file: 'dist/rollup-plugin-strip.cjs.js'
 		},
 		{
 			format: 'es',
-			dest: 'dist/rollup-plugin-strip.es.js'
+			file: 'dist/rollup-plugin-strip.es.js'
 		}
 	]
 };

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,7 @@
 import buble from 'rollup-plugin-buble';
 
 export default {
-	entry: 'src/index.js',
+	input: 'src/index.js',
 	plugins: [ buble() ],
 	targets: [
 		{
@@ -9,7 +9,7 @@ export default {
 			dest: 'dist/rollup-plugin-strip.cjs.js'
 		},
 		{
-			format: 'es6',
+			format: 'es',
 			dest: 'dist/rollup-plugin-strip.es.js'
 		}
 	]

--- a/src/index.js
+++ b/src/index.js
@@ -55,10 +55,10 @@ export default function strip ( options = {} ) {
 			let ast;
 
 			try {
-				ast = acorn.parse( code, {
+				ast = acorn.parse( code, Object.assign( {
 					ecmaVersion: 6,
 					sourceType: 'module'
-				});
+				}, options.acorn ) );
 			} catch ( err ) {
 				err.message += ` in ${id}`;
 				throw err;

--- a/src/index.js
+++ b/src/index.js
@@ -56,7 +56,7 @@ export default function strip ( options = {} ) {
 
 			try {
 				ast = acorn.parse( code, Object.assign( {
-					ecmaVersion: 6,
+					ecmaVersion: 9,
 					sourceType: 'module'
 				}, options.acorn ) );
 			} catch ( err ) {


### PR DESCRIPTION
Fixes #8.

Newer JavaScript syntax failed to parse in acorn since the ecmaVersion option was hardcoded to 6.

This PR updates dependencies, adds support for acorn option overrides, and defaults ecmaVersion to 9 (the acorn option is a bit obscure).