### PR TITLE
strip `assert` calls by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ export default {
       // remove debugger statements
       debugger: true,
 
-      // defaults to `[ 'console.*', 'assert.*' ]`
+      // defaults to `[ 'console.*', 'assert.*', 'assert' ]`
       functions: [ 'console.log', 'assert.*', 'debug', 'alert' ],
 
       // set this to `false` if you're not using sourcemaps –

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ export default function strip ( options = {} ) {
 	const sourceMap = options.sourceMap !== false;
 
 	const removeDebuggerStatements = options.debugger !== false;
-	const functions = ( options.functions || [ 'console.*', 'assert.*' ] )
+	const functions = ( options.functions || [ 'console.*', 'assert.*', 'assert' ] )
 		.map( keypath => keypath.replace( /\./g, '\\.' ).replace( /\*/g, '\\w+' ) );
 
 	const firstpass = new RegExp( `\\b(?:${functions.join( '|' )}|debugger)\\b` );


### PR DESCRIPTION
Currently, plain old `assert()` calls are not stripped by default :)