### PR TITLE
Fix object destructuring assignments with default values

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -103,7 +103,8 @@ export default function strip(options = {}) {
 				enter(node, parent) {
 					Object.defineProperty(node, 'parent', {
 						value: parent,
-						enumerable: false
+						enumerable: false,
+						configurable: true
 					});
 
 					if (sourceMap) {

--- a/test/samples/object-destructuring-default/input.js
+++ b/test/samples/object-destructuring-default/input.js
@@ -1,0 +1,4 @@
+export function fn({foo = console.log(), bar} = {}) {
+	const {baz = console.log()} = bar;
+	console.log(foo, bar, baz);
+}

--- a/test/samples/object-destructuring-default/output.js
+++ b/test/samples/object-destructuring-default/output.js
@@ -1,0 +1,3 @@
+export function fn({foo = void 0, bar} = {}) {
+	const {baz = void 0} = bar;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -73,4 +73,8 @@ describe('rollup-plugin-strip', () => {
 	it('rewrites inline while expressions as void 0', () => {
 		compare('inline-while');
 	});
+
+	it('supports object destructuring assignments with default values', () => {
+		compare('object-destructuring-default');
+	});
 });


### PR DESCRIPTION
The following code throws an error when run through `rollup-plugin-strip@1.2.1`:
```js
export function fn({foo = console.log()} = {}) {
}
```
```
TypeError: Cannot redefine property: parent
    at Function.defineProperty (<anonymous>)
    at Object.enter (dist\rollup-plugin-strip.cjs.js:108:13)
    at visit (node_modules\estree-walker\dist\estree-walker.umd.js:28:10)
    at visit (node_modules\estree-walker\dist\estree-walker.umd.js:50:5)
    at visit (node_modules\estree-walker\dist\estree-walker.umd.js:50:5)
    at visit (node_modules\estree-walker\dist\estree-walker.umd.js:45:6)
    at visit (node_modules\estree-walker\dist\estree-walker.umd.js:50:5)
    at visit (node_modules\estree-walker\dist\estree-walker.umd.js:45:6)
    at visit (node_modules\estree-walker\dist\estree-walker.umd.js:50:5)
    at visit (node_modules\estree-walker\dist\estree-walker.umd.js:45:6)
    at Object.walk (node_modules\estree-walker\dist\estree-walker.umd.js:8:3)
    at Object.transform (dist\rollup-plugin-strip.cjs.js:106:17)
```
I found that the plugin has trouble with the AST for an object destructuring assignments with default values. For example, the AST of `{foo = console.log()}` looks like this:
<details>
<summary>AST</summary>

```json
{
  "type": "ObjectPattern",
  "start": 19,
  "end": 40,
  "properties": [
    {
      "type": "Property",
      "start": 20,
      "end": 39,
      "method": false,
      "shorthand": true,
      "computed": false,
      "key": {
        "type": "Identifier",
        "start": 20,
        "end": 23,
        "name": "foo"
      },
      "kind": "init",
      "value": {
        "type": "AssignmentPattern",
        "start": 20,
        "end": 39,
        "left": {
          "type": "Identifier",
          "start": 20,
          "end": 23,
          "name": "foo"
        },
        "right": "[SNIPPED]"
      }
    }
  ]
}
```

</details>

In this AST, the two `Identifier` nodes are actually the same object: `x.properties[0].key === x.properties[0].value.left`

This poses a problem when the plugin tries to [add a `parent` property to the node](https://github.com/rollup/rollup-plugin-strip/blob/v1.2.1/src/index.js#L104):
```js
walk(ast, {
	enter(node, parent) {
		Object.defineProperty(node, 'parent', {
			value: parent,
			enumerable: false
		});
	}
});
```
When it encounters the `Identifier` for the first time, it sets the `parent` property to the `Property` node. However, when it encounters that same `Identifier` a second time with `AssignmentPattern` as parent, it must **re-define** the property with a different `value`. This is not allowed, since the property was defined as non-configurable.

I suggest we fix this by defining the `parent` property with `configurable: true`. This way, it can be changed when the node is re-visited:
```js
walk(ast, {
	enter(node, parent) {
		Object.defineProperty(node, 'parent', {
			value: parent,
			enumerable: false,
			configurable: true
		});
	}
});
```