### PR TITLE
Guard against redefining node.parent

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,10 +101,12 @@ export default function strip(options = {}) {
 
 			walk(ast, {
 				enter(node, parent) {
-					Object.defineProperty(node, 'parent', {
-						value: parent,
-						enumerable: false
-					});
+					if (!node.hasOwnProperty('parent')) {
+						Object.defineProperty(node, 'parent', {
+							value: parent,
+							enumerable: false
+						});
+					}
 
 					if (sourceMap) {
 						magicString.addSourcemapLocation(node.start);


### PR DESCRIPTION
This just bit me in a project. I don't have the time to dig into the exact cause, and I don't know this project well, but I'm taking a wild guess that this guard shouldn't actually cause any issues.