### PR TITLE
Remove labeled blocks

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.js]
+indent_style = tab
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ export default {
       // defaults to `[ 'console.*', 'assert.*' ]`
       functions: [ 'console.log', 'assert.*', 'debug', 'alert' ],
 
+      // remove one or more labeled blocks by name
+      // defaults to `[]`
+      labels: ['unittest'],
+
       // set this to `false` if you're not using sourcemaps –
       // defaults to `true`
       sourceMap: true

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,8 @@ export default function strip(options = {}) {
 		keypath => keypath.replace(/\./g, '\\.').replace(/\*/g, '\\w+')
 	);
 
+  const labels = options.labels || [];
+  
 	const firstpass = new RegExp(`\\b(?:${functions.join('|')}|debugger)\\b`);
 	const pattern = new RegExp(`^(?:${functions.join('|')})$`);
 
@@ -113,7 +115,11 @@ export default function strip(options = {}) {
 					}
 
 					if (removeDebuggerStatements && node.type === 'DebuggerStatement') {
-						removeStatement(node);
+            removeStatement(node);
+          } else if (node.type === 'LabeledStatement') {
+            if(node.label && labels.includes(node.label.name)) {
+              removeStatement(node);
+            }
 					} else if (node.type === 'CallExpression') {
 						const keypath = flatten(node.callee);
 						if (keypath && pattern.test(keypath)) {

--- a/src/index.js
+++ b/src/index.js
@@ -52,7 +52,7 @@ export default function strip(options = {}) {
 
 		transform(code, id) {
 			if (!filter(id)) return null;
-			if (!firstpass.test(code)) return null;
+			if (functions.length > 0 && !firstpass.test(code)) return null;
 
 			let ast;
 
@@ -117,7 +117,6 @@ export default function strip(options = {}) {
 					if (removeDebuggerStatements && node.type === 'DebuggerStatement') {
 						removeStatement(node);
 					} else if (node.type === 'LabeledStatement') {
-						console.log(labels);
 						if (node.label && labels.includes(node.label.name)) {
 							removeStatement(node);
 						}

--- a/src/index.js
+++ b/src/index.js
@@ -42,8 +42,8 @@ export default function strip(options = {}) {
 		keypath => keypath.replace(/\./g, '\\.').replace(/\*/g, '\\w+')
 	);
 
-  const labels = options.labels || [];
-  
+	const labels = options.labels || [];
+
 	const firstpass = new RegExp(`\\b(?:${functions.join('|')}|debugger)\\b`);
 	const pattern = new RegExp(`^(?:${functions.join('|')})$`);
 
@@ -115,11 +115,12 @@ export default function strip(options = {}) {
 					}
 
 					if (removeDebuggerStatements && node.type === 'DebuggerStatement') {
-            removeStatement(node);
-          } else if (node.type === 'LabeledStatement') {
-            if(node.label && labels.includes(node.label.name)) {
-              removeStatement(node);
-            }
+						removeStatement(node);
+					} else if (node.type === 'LabeledStatement') {
+						console.log(labels);
+						if (node.label && labels.includes(node.label.name)) {
+							removeStatement(node);
+						}
 					} else if (node.type === 'CallExpression') {
 						const keypath = flatten(node.callee);
 						if (keypath && pattern.test(keypath)) {

--- a/test/samples/label-block-discriminate/input.js
+++ b/test/samples/label-block-discriminate/input.js
@@ -1,0 +1,9 @@
+before();
+first: {
+	things();
+}
+after();
+second: {
+	assert.things();
+}
+again();

--- a/test/samples/label-block-discriminate/output.js
+++ b/test/samples/label-block-discriminate/output.js
@@ -1,0 +1,6 @@
+before();
+first: {
+	things();
+}
+after();
+again();

--- a/test/samples/label-block-multiple/input.js
+++ b/test/samples/label-block-multiple/input.js
@@ -1,0 +1,9 @@
+before();
+first: {
+	things();
+}
+after();
+second: {
+	assert.things();
+}
+again();

--- a/test/samples/label-block-multiple/output.js
+++ b/test/samples/label-block-multiple/output.js
@@ -1,0 +1,3 @@
+before();
+after();
+again();

--- a/test/samples/label-block/input.js
+++ b/test/samples/label-block/input.js
@@ -1,7 +1,7 @@
 before();
 unittest: {
-  test('some test', assert => {
-    assert.true(true);
-  });
+	test('some test', assert => {
+		assert.true(true);
+	});
 }
 after();

--- a/test/samples/label-block/input.js
+++ b/test/samples/label-block/input.js
@@ -1,5 +1,7 @@
+before();
 unittest: {
   test('some test', assert => {
     assert.true(true);
   });
 }
+after();

--- a/test/samples/label-block/input.js
+++ b/test/samples/label-block/input.js
@@ -1,0 +1,5 @@
+unittest: {
+  test('some test', assert => {
+    assert.true(true);
+  });
+}

--- a/test/samples/label-block/output.js
+++ b/test/samples/label-block/output.js
@@ -1,0 +1,2 @@
+before();
+after();

--- a/test/test.js
+++ b/test/test.js
@@ -85,4 +85,8 @@ describe('rollup-plugin-strip', () => {
 	it('removes multiple labeled blocks', () => {
 		compare('label-block-multiple', { labels: ['first', 'second'] });
 	});
+	
+	it('only removes specified blocks', () => {
+		compare('label-block-discriminate', { labels: ['second'] });
+	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -76,5 +76,9 @@ describe('rollup-plugin-strip', () => {
 
 	it('supports object destructuring assignments with default values', () => {
 		compare('object-destructuring-default');
-	});
+  });
+  
+  it('removes labeled blocks', () => {
+    compare('label-block');
+  })
 });

--- a/test/test.js
+++ b/test/test.js
@@ -82,4 +82,7 @@ describe('rollup-plugin-strip', () => {
 		compare('label-block', { labels: ['unittest'] });
 	});
 
+	it('removes multiple labeled blocks', () => {
+		compare('label-block-multiple', { labels: ['first', 'second'] });
+	});
 });

--- a/test/test.js
+++ b/test/test.js
@@ -79,6 +79,6 @@ describe('rollup-plugin-strip', () => {
   });
   
   it('removes labeled blocks', () => {
-    compare('label-block');
-  })
+    compare('label-block', { labels: ['unittest'] });
+  });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -76,9 +76,10 @@ describe('rollup-plugin-strip', () => {
 
 	it('supports object destructuring assignments with default values', () => {
 		compare('object-destructuring-default');
-  });
-  
-  it('removes labeled blocks', () => {
-    compare('label-block', { labels: ['unittest'] });
-  });
+	});
+
+	it('removes labeled blocks', () => {
+		compare('label-block', { labels: ['unittest'] });
+	});
+
 });


### PR DESCRIPTION
Inspired by [D’s `unittest`](https://twitter.com/james_k_nelson/status/1165626350159269888), I want to “inline” my unit tests in the code that they test so that they always live together. Obviously, I’ll need to strip out the tests in production. JavaScript labels seem like a sensible way achieve this. 

Input:

```js
before();
unittest: {
  test('some test', assert => {
    assert.true(true);
  });
}
after();
```

Plugin config:

```js
// …
plugins: [
  strip({ labels: ['unittest'] })
]
// …
```

Output:

```js
before();
after();
```